### PR TITLE
Update Makefiles (PA 6 & 7) to avoid recompiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Sentinel files to allow `make` to track whether multiple files in a folder
+# have already been compiled
+# https://tech.davis-hansson.com/p/make/#sentinel-files
+*.sentinel
+
 # Created by https://www.toptal.com/developers/gitignore/api/c++,cuda,linux,macos,python,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=c++,cuda,linux,macos,python,windows
 
@@ -65,7 +70,8 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
-
+Icon
 
 # Thumbnails
 ._*

--- a/PA6/Makefile
+++ b/PA6/Makefile
@@ -1,18 +1,20 @@
-m1:		m1.o ece408net.o network.o mnist.o layer loss custom
+m1:		m1.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel custom.sentinel
 		nvcc -o m1 -lm -lcuda -lrt m1.o ece408net.o src/network.o src/mnist.o src/layer/*.o src/loss/*.o src/layer/custom/*.o ../libgputk/lib/libgputk.a -I./
 
-m2:		m2.o custom
+m2:		m2.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel custom.sentinel
 		nvcc -o m2 -lm -lcuda -lrt m2.o ece408net.o src/network.o src/mnist.o src/layer/*.o src/loss/*.o src/layer/custom/*.o ../libgputk/lib/libgputk.a -I./ 
 
 debug:	debug_m1
 
-debug_m1: m1.o ece408net.o network.o mnist.o layer loss
+debug_m1: m1.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel src/layer/custom/cpu-new-forward.cc src/layer/custom/gpu-utils.cu src/layer/custom/new-forward.cu
+		rm custom.sentinel
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query`  --compile src/layer/custom/cpu-new-forward.cc -o src/layer/custom/cpu-new-forward.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query`  --compile src/layer/custom/gpu-utils.cu -o src/layer/custom/gpu-utils.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query`  --compile src/layer/custom/new-forward.cu -o src/layer/custom/new-forward.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query` -o m1 -lm -lcuda -lrt m1.o ece408net.o src/network.o src/mnist.o src/layer/*.o src/loss/*.o src/layer/custom/*.o ../libgputk/lib/libgputk.a -I./ 
 
-debug_m2: m1.o ece408net.o network.o mnist.o layer loss
+debug_m2: m1.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel src/layer/custom/cpu-new-forward.cc src/layer/custom/gpu-utils.cu src/layer/custom/new-forward.cu
+		rm custom.sentinel
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query`  --compile src/layer/custom/cpu-new-forward.cc -o src/layer/custom/cpu-new-forward.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query`  --compile src/layer/custom/gpu-utils.cu -o src/layer/custom/gpu-utils.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/cuda/bin/__nvcc_device_query`,code=sm_`/usr/local/cuda/bin/__nvcc_device_query`  --compile src/layer/custom/new-forward.cu -o src/layer/custom/new-forward.o -I ../libgputk/ -I./
@@ -27,13 +29,13 @@ m1.o:		m1.cc
 ece408net.o:    ece408net.cc
 		nvcc --compile ece408net.cc -I ../libgputk/ -I./
 
-network.o:	src/network.cc
+src/network.o:	src/network.cc
 		nvcc --compile src/network.cc -o src/network.o -I ../libgputk/ -I./
 
-mnist.o:	src/mnist.cc
+src/mnist.o:	src/mnist.cc
 		nvcc --compile src/mnist.cc -o src/mnist.o -I ../libgputk/ -I./
 
-layer:		src/layer/conv.cc src/layer/ave_pooling.cc src/layer/conv_cpu.cc src/layer/conv_cust.cc src/layer/fully_connected.cc src/layer/max_pooling.cc src/layer/relu.cc src/layer/sigmoid.cc src/layer/softmax.cc 
+layer.sentinel:		src/layer/conv.cc src/layer/ave_pooling.cc src/layer/conv_cpu.cc src/layer/conv_cust.cc src/layer/fully_connected.cc src/layer/max_pooling.cc src/layer/relu.cc src/layer/sigmoid.cc src/layer/softmax.cc 
 		nvcc --compile src/layer/ave_pooling.cc -o src/layer/ave_pooling.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/conv.cc -o src/layer/conv.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/conv_cpu.cc -o src/layer/conv_cpu.o -I ../libgputk/ -I./
@@ -43,21 +45,25 @@ layer:		src/layer/conv.cc src/layer/ave_pooling.cc src/layer/conv_cpu.cc src/lay
 		nvcc --compile src/layer/relu.cc -o src/layer/relu.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/sigmoid.cc -o src/layer/sigmoid.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/softmax.cc -o src/layer/softmax.o -I ../libgputk/ -I./
+		touch layer.sentinel
 
-custom:
+custom.sentinel: src/layer/custom/cpu-new-forward.cc src/layer/custom/gpu-utils.cu src/layer/custom/new-forward.cu
 		nvcc --compile src/layer/custom/cpu-new-forward.cc -o src/layer/custom/cpu-new-forward.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/custom/gpu-utils.cu -o src/layer/custom/gpu-utils.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/custom/new-forward.cu -o src/layer/custom/new-forward.o -I ../libgputk/ -I./
+		touch custom.sentinel
 
-loss:           src/loss/cross_entropy_loss.cc src/loss/mse_loss.cc
+loss.sentinel:           src/loss/cross_entropy_loss.cc src/loss/mse_loss.cc
 		nvcc --compile src/loss/cross_entropy_loss.cc -o src/loss/cross_entropy_loss.o -I ../libgputk/ -I./
 		nvcc --compile src/loss/mse_loss.cc -o src/loss/mse_loss.o -I ../libgputk/ -I./
+		touch loss.sentinel
 
 
 clean:
 		rm m1
 		rm m1.o
 		find . -name "*.o" -type f -delete
+		rm *.sentinel
 
 run: 		m1
 		./m1 1000

--- a/PA7/Makefile
+++ b/PA7/Makefile
@@ -1,18 +1,20 @@
-m2:		m2.o ece408net.o network.o mnist.o layer loss custom
+m2:		m2.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel custom.sentinel
 		nvcc -o m2 -lm -lcuda -lrt m2.o ece408net.o src/network.o src/mnist.o src/layer/*.o src/loss/*.o src/layer/custom/*.o ../libgputk/lib/libgputk.a -I./ 
 
-m1:		m1.o ece408net.o network.o mnist.o layer loss custom
+m1:		m1.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel custom.sentinel
 		nvcc -o m1 -lm -lcuda -lrt m1.o ece408net.o src/network.o src/mnist.o src/layer/*.o src/loss/*.o src/layer/custom/*.o ../libgputk/lib/libgputk.a -I./
 
 debug:	debug_m2
 
-debug_m1: m1.o ece408net.o network.o mnist.o layer loss
+debug_m1: m1.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel src/layer/custom/cpu-new-forward.cc src/layer/custom/gpu-utils.cu src/layer/custom/new-forward.cu
+		rm custom.sentinel
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`  --compile src/layer/custom/cpu-new-forward.cc -o src/layer/custom/cpu-new-forward.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`  --compile src/layer/custom/gpu-utils.cu -o src/layer/custom/gpu-utils.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`  --compile src/layer/custom/new-forward.cu -o src/layer/custom/new-forward.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .` -o m1 -lm -lcuda -lrt m1.o ece408net.o src/network.o src/mnist.o src/layer/*.o src/loss/*.o src/layer/custom/*.o ../libgputk/lib/libgputk.a -I./ 
 
-debug_m2: m2.o ece408net.o network.o mnist.o layer loss
+debug_m2: m2.o ece408net.o src/network.o src/mnist.o layer.sentinel loss.sentinel src/layer/custom/cpu-new-forward.cc src/layer/custom/gpu-utils.cu src/layer/custom/new-forward.cu
+		rm custom.sentinel
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`  --compile src/layer/custom/cpu-new-forward.cc -o src/layer/custom/cpu-new-forward.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`  --compile src/layer/custom/gpu-utils.cu -o src/layer/custom/gpu-utils.o -I ../libgputk/ -I./
 		nvcc -g -G -gencode arch=compute_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`,code=sm_`/usr/local/nvidia/bin/nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1 | tr -d .`  --compile src/layer/custom/new-forward.cu -o src/layer/custom/new-forward.o -I ../libgputk/ -I./
@@ -27,13 +29,13 @@ m2.o:		m2.cc
 ece408net.o:    ece408net.cc
 		nvcc --compile ece408net.cc -I ../libgputk/ -I./
 
-network.o:	src/network.cc
+src/network.o:	src/network.cc
 		nvcc --compile src/network.cc -o src/network.o -I ../libgputk/ -I./
 
-mnist.o:	src/mnist.cc
+src/mnist.o:	src/mnist.cc
 		nvcc --compile src/mnist.cc -o src/mnist.o -I ../libgputk/ -I./
 
-layer:		src/layer/conv.cc src/layer/ave_pooling.cc src/layer/conv_cpu.cc src/layer/conv_cust.cc src/layer/fully_connected.cc src/layer/max_pooling.cc src/layer/relu.cc src/layer/sigmoid.cc src/layer/softmax.cc 
+layer.sentinel:		src/layer/conv.cc src/layer/ave_pooling.cc src/layer/conv_cpu.cc src/layer/conv_cust.cc src/layer/fully_connected.cc src/layer/max_pooling.cc src/layer/relu.cc src/layer/sigmoid.cc src/layer/softmax.cc 
 		nvcc --compile src/layer/ave_pooling.cc -o src/layer/ave_pooling.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/conv.cc -o src/layer/conv.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/conv_cpu.cc -o src/layer/conv_cpu.o -I ../libgputk/ -I./
@@ -43,21 +45,25 @@ layer:		src/layer/conv.cc src/layer/ave_pooling.cc src/layer/conv_cpu.cc src/lay
 		nvcc --compile src/layer/relu.cc -o src/layer/relu.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/sigmoid.cc -o src/layer/sigmoid.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/softmax.cc -o src/layer/softmax.o -I ../libgputk/ -I./
+		touch layer.sentinel
 
-custom:
+custom.sentinel: src/layer/custom/cpu-new-forward.cc src/layer/custom/gpu-utils.cu src/layer/custom/new-forward.cu
 		nvcc --compile src/layer/custom/cpu-new-forward.cc -o src/layer/custom/cpu-new-forward.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/custom/gpu-utils.cu -o src/layer/custom/gpu-utils.o -I ../libgputk/ -I./
 		nvcc --compile src/layer/custom/new-forward.cu -o src/layer/custom/new-forward.o -I ../libgputk/ -I./
+		touch custom.sentinel
 
-loss:           src/loss/cross_entropy_loss.cc src/loss/mse_loss.cc
+loss.sentinel:           src/loss/cross_entropy_loss.cc src/loss/mse_loss.cc
 		nvcc --compile src/loss/cross_entropy_loss.cc -o src/loss/cross_entropy_loss.o -I ../libgputk/ -I./
 		nvcc --compile src/loss/mse_loss.cc -o src/loss/mse_loss.o -I ../libgputk/ -I./
+		touch loss.sentinel
 
 
 clean:
 		rm m2
 		rm m2.o
 		find . -name "*.o" -type f -delete
+		rm *.sentinel
 
 run: 		m2
 		./m2 1000


### PR DESCRIPTION
Currently, the Makefiles recompile a lot of the dependencies every time `make run` is called. This can take a while.

This is because the Makefile dependencies depend on nonexistent files like `loss`, `layer`, and `custom`, so `make` will try to recompile them every time.

One way around this is to generate [sentinel files](https://tech.davis-hansson.com/p/make/#sentinel-files), one for each folder. `make` can use their modification dates to figure out whether the entire folder needs to be recompiled or not.

Here are the changes in this PR:

- Use sentinel files for `src/loss`, `src/layer`, and `src/layer/custom`
- Because `make` won't recompile `custom` every time anymore, I had to add its source files to `custom.sentinel`'s dependencies
- Similarly, the `debug_*` targets compile files in `src/layer/custom`, but they aren't listed in their dependencies.
  - I also made them remove `custom.sentinel` at the beginning because it overwrites the `.o` files in `src/layer/custom`. This way, if someone runs `make debug_m1` then `make m1`, the `.o` files in `src/layer/custom` can get recompiled with the debug flags off.
- network.o and mnist.o are both in src/, so they currently get recompiled every time. I fixed this by using src/network.o and src/mnist.o instead, so `make` can use their modified times